### PR TITLE
allows to get some more tor options like DNS and TransPort

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,10 @@ class tor (
 	$dirport                    = '9000',
 	$dirlistenaddress           = '0.0.0.0:9000',
 	$hidden_services            = [],
+        $transPort                  = false,
+        $transListenAddress         = '127.0.0.1',
+        $dnsPort                    = false,
+        $dnsListenAddress           = '127.0.0.1',
 ) {
 
 	package { 'tor':

--- a/templates/torrc.erb
+++ b/templates/torrc.erb
@@ -28,6 +28,16 @@ SocksPort 0
 SocksListenAddress 127.0.0.1
 <%- end -%>
 
+<%- if @dnsPort -%>
+DNSPort <%= @dnsPort %>
+DNSListenAddress <%= @dnsListenAddress %>
+<%- end -%>
+
+<%- if @transPort -%>
+TransPort <%= @transPort %>
+TransListenAddress <%= @transListenAddress %>
+<%- end -%>
+
 ## Logs go to stdout at level "notice" unless redirected by something
 ## else, like one of the below lines. You can have as many Log lines as
 ## you want.


### PR DESCRIPTION
Might be cleaner to pass some hash-config to the ::tor class. This might be easier to extend with new Tor options in the future?

Anyway, this patch just adds new capabilities for now, without breaking anything :).
